### PR TITLE
Count tests with multiple expectation statuses as failure (#5)

### DIFF
--- a/preprocess-data.js
+++ b/preprocess-data.js
@@ -24,6 +24,9 @@ async function parseExpectations(url) {
           counts.skipping++;
           break;
       }
+    } else {
+      // tests with multiple statuses are counted as failures
+      counts.failing++;
     }
   }
   return counts;


### PR DESCRIPTION
This adds the currently 22 tests with multiple statuses to the list of failing tests. If we aren't doing that they won't be counted at all.