### PR TITLE
Include the tests out of scope in the graph

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -28,7 +28,7 @@ function renderChart(chartData) {
       vAxis: { minValue: 0 },
       hAxis: { format: 'MMM d' },
       isStacked: true,
-      colors:['#3366cc', '#dc3912', '#ff9900', '#aaaaaa'],
+      colors: ['#3366cc', '#dc3912', '#ff9900', '#aaaaaa'],
     };
 
     const chart = new google.visualization.AreaChart(document.querySelector('#chart'));

--- a/main.mjs
+++ b/main.mjs
@@ -28,6 +28,7 @@ function renderChart(chartData) {
       vAxis: { minValue: 0 },
       hAxis: { format: 'MMM d' },
       isStacked: true,
+      colors:['#3366cc', '#dc3912', '#ff9900', '#aaaaaa'],
     };
 
     const chart = new google.visualization.AreaChart(document.querySelector('#chart'));
@@ -42,12 +43,12 @@ async function main() {
   const response = await fetch('./data.json');
   const entries = await response.json();
   const chartData = [
-    ['date', 'passing tests', 'failing tests', 'skipping tests'],
+    ['date', 'tests passed', 'tests failed', 'tests skipped', 'out of scope'],
   ];
   for (const entry of entries) {
     const { date, counts } = entry;
     chartData.push(
-      [new Date(date), counts.passing, counts.failing, counts.skipping]
+      [new Date(date), counts.passing, counts.failing, counts.skipping, counts.unsupported]
     );
     console.log(`${ new Date(date).toUTCString() }: ${ format(counts) }`);
   }

--- a/preprocess-data.js
+++ b/preprocess-data.js
@@ -29,6 +29,9 @@ async function parseExpectations(url) {
       counts.failing++;
     }
   }
+
+  counts.unsupported = counts.total - (counts.passing + counts.failing + counts.skipping);
+
   return counts;
 }
 


### PR DESCRIPTION
Currently when you add the numbers for all the passed, failed, and skipped tests the result will not match the total number. The reason is that a couple of tests are Chrome-only and we do not run these.

As internally discussed it would be great to have these `out of scope` tests also be included in the graph. The PR adds it at the top as a gray bar. Plus point for that is also that way we can easily see when the total number of tests changes, like for an upgrade of our internal puppeteer downstream code.

@mathiasbynens mind reviewing? Thanks.