### PR TITLE
Generate BiDi stats for Firefox

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "username@users.noreply.github.com"
           git add data --all
-          git commit -a -m "Test results obtains via GitHub Actions"
+          git commit -a -m "Test results obtained via GitHub Actions"
           git push
       - name: Build
         run: |

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "html-minifier": "^4.0.0",
     "http-server": "^0.12.3",
-    "puppeteer": "^3.0.4"
+    "puppeteer": "^19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
   "devDependencies": {
     "html-minifier": "^4.0.0",
     "http-server": "^0.12.3",
-    "node-fetch": "^2.6.0",
-    "puppeteer": "^3.0.4",
-    "whatwg-fetch": "^3.0.0"
+    "puppeteer": "^3.0.4"
   }
 }

--- a/preprocess-data.js
+++ b/preprocess-data.js
@@ -4,13 +4,15 @@ async function main() {
   const files = fs.readdirSync('./data');
   const data = files.filter(file => file.endsWith('.json')).sort().map(file => {
     const stats = JSON.parse(fs.readFileSync('./data/' + file, 'utf-8')).stats;
+    // Since few tests are supported we don't report the skipped tests to make
+    // sure the chart is readable.
     const counts = {
       passing: stats.passes,
       failing: stats.failures,
-      skipping: stats.pending,
+      skipping: 0, // stats.pending,
       total: stats.tests,
     }
-    counts.unsupported = counts.total - (counts.passing + counts.failing + counts.skipping);
+    counts.unsupported = 0; // counts.total - (counts.passing + counts.failing + counts.skipping);
     return {
       date: Number(file.split('.').shift()) * 1000,
       counts,

--- a/preprocess-data.js
+++ b/preprocess-data.js
@@ -1,69 +1,22 @@
-const fs = require('fs').promises;
-const fetch = require('node-fetch');
-
-const baseURL = 'https://hg.mozilla.org/mozilla-central/';
-
-const filePaths = [
-  'remote/test/puppeteer-expected.json',
-  'remote/puppeteer-expected.json',
-];
-
-async function parseExpectations(url) {
-  const response = await fetch(url);
-  const expectations = await response.json();
-  const counts = {
-    passing: 0,
-    failing: 0,
-    skipping: 0,
-    total: 0,
-  };
-  for (const [name, expectation] of Object.entries(expectations)) {
-    counts.total++;
-    if (expectation.length === 1) {
-      switch (expectation[0]) {
-        case 'PASS':
-          counts.passing++;
-          break;
-        case 'FAIL':
-          counts.failing++;
-          break;
-        case 'SKIP':
-          counts.skipping++;
-          break;
-      }
-    } else {
-      // tests with multiple statuses are counted as failures
-      counts.failing++;
-    }
-  }
-
-  counts.unsupported = counts.total - (counts.passing + counts.failing + counts.skipping);
-
-  return counts;
-}
-
-async function getLogEntries(path) {
-  const response = await fetch(`${baseURL}/json-log/tip/${path}`);
-  const data = await response.json();
-  return data.entries;
-}
+const fs = require('fs');
 
 async function main() {
-  const data = [];
-
-  for (const filePath of filePaths) {
-    const entries = await getLogEntries(filePath);
-    for (const entry of entries) {
-      const date = entry.date[0] * 1000;
-      const revision = entry.node;
-      const url = `${baseURL}/raw-file/${revision}/${filePath}`;
-      const counts = await parseExpectations(url);
-      data.push({ date, counts });
+  const files = fs.readdirSync('./data');
+  const data = files.filter(file => file.endsWith('.json')).sort().map(file => {
+    const stats = JSON.parse(fs.readFileSync('./data/' + file, 'utf-8')).stats;
+    const counts = {
+      passing: stats.passes,
+      failing: stats.failures,
+      skipping: stats.pending,
+      total: stats.tests,
     }
-  };
-
-  data.sort((a, b) => a.date - b.date);
-  fs.writeFile('data.json', JSON.stringify(data, null, 2));
+    counts.unsupported = counts.total - (counts.passing + counts.failing + counts.skipping);
+    return {
+      date: Number(file.split('.').shift()) * 1000,
+      counts,
+    }
+  });
+  fs.writeFileSync('data.json', JSON.stringify(data, null, 2));
   console.log(data);
 }
 


### PR DESCRIPTION
This updates the chart data with BiDi for Firefox. I turned off reporting of skipped tests because very few tests are passing making the chart unreadable. Once this lands, I will rename the repo and will set up a redirect.

Note that I pushed the data collection already that will now happen in GitHub actions of this repository daily instead of fetching data from elsewhere.

cc @mathiasbynens @whimboo 